### PR TITLE
added import for PSDesiredStateConfiguration

### DIFF
--- a/dsc/pullServer.md
+++ b/dsc/pullServer.md
@@ -49,7 +49,8 @@ configuration Sample_xDscPullServer
      ) 
  
  
-     Import-DSCResource -ModuleName xPSDesiredStateConfiguration 
+     Import-DSCResource -ModuleName xPSDesiredStateConfiguration
+     Import-DSCResource –ModuleName PSDesiredStateConfiguration
 
      Node $NodeName 
      { 


### PR DESCRIPTION
Prevents: WARNING: The configuration 'ConfigurePullServer' is loading one or more built-in resources without explicitly importing
 associated modules. Add Import-DscResource –ModuleName 'PSDesiredStateConfiguration' to your configuration to avoid
this message.